### PR TITLE
给orbuculum-web添加tracing middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +921,8 @@ dependencies = [
  "orbuculum-web",
  "serde_json",
  "tokio",
+ "tower-http",
+ "tracing",
  "udev",
 ]
 
@@ -977,12 +985,15 @@ name = "orbuculum-web"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "env_logger",
  "eyre",
  "orbuculum-grpc",
  "serde",
  "serde_json",
  "tokio",
  "tonic",
+ "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -1743,6 +1754,25 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ orbuculum-nm = { version = "0.0.1", path = "crates/orbuculum-nm" }
 orbuculum-grpc = { version = "0.0.1", path = "crates/orbuculum-grpc" }
 orbuculum-rules = { version = "0.0.1", path = "crates/orbuculum-rules" }
 tokio = { version = "1.23.0", features = ["full"] }
+tower-http = { version = "0.4.0", features = ["trace"] }
+tracing = "0.1.37"
 udev = "0.7.0"
 serde_json = "1.0.95"
 axum = "0.6.12"

--- a/crates/orbuculum-web/Cargo.toml
+++ b/crates/orbuculum-web/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+env_logger = "0.10.0"
 axum = "0.6.12"
 eyre = "0.6.8"
 serde = { version = "1.0.159", features = ["derive"] }
@@ -13,3 +14,5 @@ serde_json = "1.0.95"
 orbuculum-grpc = { version = "0.0.1", path = "../orbuculum-grpc" }
 tokio = "1.27.0"
 tonic = "0.8.3"
+tower-http = { version = "0.4.0", features = ["trace"] }
+tracing = "0.1.37"

--- a/crates/orbuculum-web/src/lib.rs
+++ b/crates/orbuculum-web/src/lib.rs
@@ -1,6 +1,11 @@
 use orbuculum_grpc::{NetworkClient, ConnectionUuidRequest};
 use axum::extract::Path;
+use axum::http::StatusCode;
 use serde_json::Value;
+
+pub async fn health() -> StatusCode {
+    StatusCode::OK
+}
 
 pub async fn list_devices() -> axum::extract::Json<Value> {
     let mut client = NetworkClient::connect("http://127.0.0.1:50051").await.unwrap();

--- a/scripts/aliases/cargo-docker.sh
+++ b/scripts/aliases/cargo-docker.sh
@@ -5,4 +5,4 @@ rust_log="-e RUST_LOG=debug"
 
 alias xcargo="docker run --network=host --rm $proxy $rust_log -v '$(pwd):/work' -v '$HOME/.cargo/git:/root/.cargo/git:rw' -v '$HOME/.cargo/registry:/root/.cargo/registry:rw' --workdir /work -ti docker.io/ssfdust/orbuculum-dev cargo"
 alias xbash="docker run --network=host --rm $proxy -v '$(pwd):/work' -v '$HOME/.cargo/git:/root/.cargo/git:rw' -v '$HOME/.cargo/registry:/root/.cargo/registry:rw' --workdir /work -ti docker.io/ssfdust/orbuculum-dev bash"
-alias xstop="docker ps -a | grep orbuculum | awk '{ print $1 }' | xargs docker stop"
+alias xstop="docker ps -a | grep orbuculum | awk '{ print \$1 }' | xargs docker stop"

--- a/src/bin/orbuculum-web.rs
+++ b/src/bin/orbuculum-web.rs
@@ -1,16 +1,43 @@
 use axum::routing::get;
-use orbuculum_web::{get_connection_by_uuid, list_connections, list_devices};
+use orbuculum_web::{get_connection_by_uuid, list_connections, list_devices, health};
+use tracing::{Level, info};
+use tower_http::{
+    LatencyUnit,
+    trace::{TraceLayer, DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse},
+};
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
+
+    let addr = "0.0.0.0:3000";
+
     // Build our application by creating our router.
     let app = axum::Router::new()
         .route("/api/proxy/devices", get(list_devices))
         .route("/api/proxy/connections", get(list_connections))
-        .route("/api/proxy/connection/:uuid", get(get_connection_by_uuid));
+        .route("/api/proxy/connection/:uuid", get(get_connection_by_uuid))
+        // health with tracing
+        .route("/health", get(health))
+        .layer(TraceLayer::new_for_http()
+                .make_span_with(
+                    DefaultMakeSpan::new().include_headers(true)
+                )
+                .on_request(
+                    DefaultOnRequest::new().level(Level::INFO)
+                )
+                .on_response(
+                    DefaultOnResponse::new()
+                        .level(Level::INFO)
+                        .latency_unit(LatencyUnit::Micros)
+                ))
+        // healhz without tracing
+        .route("/healthz", get(health));
+
+    info!("Web starts at {}", addr);
 
     // Run our application as a hyper server on http://localhost:3000.
-    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
+    axum::Server::bind(&addr.parse().unwrap())
         .serve(app.into_make_service())
         .await
         .unwrap();

--- a/src/bin/orbuculum-web.rs
+++ b/src/bin/orbuculum-web.rs
@@ -31,7 +31,7 @@ async fn main() {
                         .level(Level::INFO)
                         .latency_unit(LatencyUnit::Micros)
                 ))
-        // healhz without tracing
+        // healthz without tracing
         .route("/healthz", get(health));
 
     info!("Web starts at {}", addr);


### PR DESCRIPTION
```
   Compiling orbuculum v0.1.0 (/work)
    Finished dev [unoptimized + debuginfo] target(s) in 7.06s
     Running `target/debug/orbuculum-web`
[2023-04-02T11:32:47Z INFO  orbuculum_web] Web starts at 0.0.0.0:3000
[2023-04-02T11:32:52Z DEBUG hyper::proto::h1::io] parsed 3 headers
[2023-04-02T11:32:52Z DEBUG hyper::proto::h1::conn] incoming body is empty
[2023-04-02T11:32:52Z DEBUG tower_http::trace::make_span] request; method=GET uri=/health version=HTTP/1.1 headers={"host": "127.0.0.1:3000", "user-agent": "curl/7.85.0", "accept": "*/*"}
[2023-04-02T11:32:52Z INFO  tower_http::trace::on_request] started processing request
[2023-04-02T11:32:52Z INFO  tower_http::trace::on_response] finished processing request latency=163 μs status=200
[2023-04-02T11:32:52Z DEBUG hyper::proto::h1::io] flushed 75 bytes
[2023-04-02T11:32:52Z DEBUG hyper::proto::h1::conn] read eof
[2023-04-02T11:32:56Z DEBUG hyper::proto::h1::io] parsed 3 headers
[2023-04-02T11:32:56Z DEBUG hyper::proto::h1::conn] incoming body is empty
[2023-04-02T11:32:56Z DEBUG hyper::proto::h1::io] flushed 75 bytes
[2023-04-02T11:32:56Z DEBUG hyper::proto::h1::conn] read eof
```